### PR TITLE
Config depends on commerce_tax

### DIFF
--- a/commerce_demo.info.yml
+++ b/commerce_demo.info.yml
@@ -7,6 +7,7 @@ dependencies:
   - color_field:color_field
   - commerce:commerce
   - commerce:commerce_product
+  - commerce:commerce_tax
   - commerce_shipping:commerce_shipping
   - facets:facets
   - facets_pretty_paths:facets_pretty_paths


### PR DESCRIPTION
```
  [Drupal\Core\Config\UnmetDependenciesException]                              
  Configuration objects provided by <em class="placeholder">commerce_demo</em  
  > have unmet dependencies: <em class="placeholder">commerce_order.commerce_  
  order_item_type.physical_product_variation (commerce_tax)</em> 
```

commerce_order.commerce_order_item_type.physical_product_variation needs commerce_tax